### PR TITLE
Add verbose parameter

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # data-utils
-![version](https://img.shields.io/badge/version-0.4.1-blue)
+![version](https://img.shields.io/badge/version-0.4.2-blue)
 ![version](https://img.shields.io/badge/python-3.8-blue.svg?&logo=python&logoColor=yellow) [![codecov](https://codecov.io/gh/owid/data-utils-py/branch/main/graph/badge.svg?token=2emTQEJedw)](https://codecov.io/gh/owid/data-utils-py)
 
 `data-utils` is a library to support the work of the Data Team at Our World in Data.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2022, Our World In Data"
 author = "Our World In Data"
 
 # The full version, including alpha/beta/rc tags
-release = "0.4.1"
+release = "0.4.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/owid/datautils/__init__.py
+++ b/owid/datautils/__init__.py
@@ -1,3 +1,3 @@
 """Library to support the work of the Data Team at Our World in Data."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/owid/datautils/geo.py
+++ b/owid/datautils/geo.py
@@ -127,6 +127,7 @@ def list_countries_in_region_that_must_have_data(
     countries_regions: Optional[pd.DataFrame] = None,
     income_groups: Optional[pd.DataFrame] = None,
     population: Optional[pd.DataFrame] = None,
+    verbose: bool = False,
 ) -> List[str]:
     """List countries of a region that are expected to have the largest contribution to any variable.
 
@@ -155,6 +156,8 @@ def list_countries_in_region_that_must_have_data(
         Income-groups dataset, or None, to load it from the catalog.
     population : pd.DataFrame or None
         Population dataset, or None, to load it from owid catalog.
+    verbose : bool
+        True to print the number of countries (and percentage of cumulative population) that must have data.
 
     Returns
     -------
@@ -220,11 +223,12 @@ def list_countries_in_region_that_must_have_data(
         )
         selected = reference.copy()
 
-    print(
-        f"{len(selected)} countries must be informed for {region} (covering"
-        f" {selected['fraction'].sum() * 100: .2f}% of the population; otherwise"
-        " aggregate data will be nan."
-    )
+    if verbose:
+        print(
+            f"{len(selected)} countries must be informed for {region} (covering"
+            f" {selected['fraction'].sum() * 100: .2f}% of the population; otherwise"
+            " aggregate data will be nan."
+        )
     countries = selected["country"].tolist()  # type: List[str]
 
     return countries

--- a/owid/datautils/geo.py
+++ b/owid/datautils/geo.py
@@ -208,10 +208,6 @@ def list_countries_in_region_that_must_have_data(
         selected = selected.loc[0 : candidates_to_ignore.index[0]]
 
     if (min_frac_individual_population == 0) and (min_frac_cumulative_population == 0):
-        warnings.warn(
-            "Conditions are too loose to select countries that must be included in the"
-            " data."
-        )
         selected = pd.DataFrame({"country": [], "fraction": []})
     elif (len(selected) == 0) or (
         (len(selected) == len(reference)) and (len(reference) > 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-datautils"
-version = "0.4.1"
+version = "0.4.2"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = ["Our World In Data <tech@ourworldindata.org>"]
 license = "MIT"

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -329,21 +329,6 @@ class TestListCountriesInRegions(unittest.TestCase):
 
 
 class TestListCountriesInRegionsThatMustHaveData(unittest.TestCase):
-    def test_having_too_loose_conditions(self):
-        with self.assertWarns(UserWarning):
-            assert (
-                geo.list_countries_in_region_that_must_have_data(
-                    region="Region 1",
-                    reference_year=2020,
-                    min_frac_individual_population=0.0,
-                    min_frac_cumulative_population=0.0,
-                    countries_regions=mock_countries_regions,
-                    income_groups=mock_income_groups,
-                    population=mock_population,
-                )
-                == []
-            )
-
     def test_having_too_strict_condition_on_minimum_individual_contribution(self):
         with self.assertWarns(UserWarning):
             assert geo.list_countries_in_region_that_must_have_data(


### PR DESCRIPTION
Add a "verbose" argument to avoid having too many prints when using one of the geo functions in a data pipeline.
