### PR TITLE
fix(pyproject): assign the correct version to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ ipdb = "^0.13.9"
 ipykernel = "^6.13.0"
 
 [build-system]
-requires = ["poetry-core>=1.1.0"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
It turns out the latest 1.1.0 poetry-core versions are pre-release only, so we have to go back to 1.0.0.
