### PR TITLE
enhance(dataframes): improve performance of groupby_agg on categoricals

### DIFF
--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -265,7 +265,7 @@ def groupby_agg(
         Grouped dataframe after applying aggregations.
 
     """
-    if type(groupby_columns) == str:
+    if isinstance(groupby_columns, str):
         groupby_columns = [groupby_columns]
 
     if aggregations is None:
@@ -274,30 +274,62 @@ def groupby_agg(
         ]
         aggregations = {column: "sum" for column in columns_to_aggregate}
 
+    # Default groupby arguments, `observed` makes sure the final dataframe
+    # does not explode with NaNs
+    groupby_kwargs = {
+        "dropna": False,
+        "observed": True,
+    }
+
     # Group by and aggregate.
-    grouped = df.groupby(groupby_columns, dropna=False).agg(aggregations)
+    grouped = df.groupby(groupby_columns, **groupby_kwargs).agg(aggregations)  # type: ignore
 
     if num_allowed_nans is not None:
         # Count the number of missing values in each group.
-        num_nans_detected = df.groupby(groupby_columns, dropna=False).agg(
-            lambda x: pd.isnull(x).sum()
+        num_nans_detected = count_missing_in_groups(
+            df, groupby_columns, **groupby_kwargs
         )
+
         # Make nan any aggregation where there were too many missing values.
         grouped = grouped[num_nans_detected <= num_allowed_nans]
 
     if frac_allowed_nans is not None:
         # Count the number of missing values in each group.
-        num_nans_detected = df.groupby(groupby_columns, dropna=False).agg(
-            lambda x: pd.isnull(x).sum()
+        num_nans_detected = count_missing_in_groups(
+            df, groupby_columns, **groupby_kwargs
         )
         # Count number of elements in each group (avoid using 'count' method, which ignores nans).
-        num_elements = df.groupby(groupby_columns, dropna=False).size()
+        num_elements = df.groupby(groupby_columns, **groupby_kwargs).size()  # type: ignore
         # Make nan any aggregation where there were too many missing values.
         grouped = grouped[
             num_nans_detected.divide(num_elements, axis="index") <= frac_allowed_nans
         ]
 
     return grouped
+
+
+def count_missing_in_groups(
+    df: pd.DataFrame, groupby_columns: List[str], **kwargs: Any
+) -> pd.DataFrame:
+    """Count the number of missing values in each group.
+
+    Faster version of
+    ```
+    num_nans_detected = df.groupby(groupby_columns, **groupby_kwargs).agg(
+        lambda x: pd.isnull(x).sum()
+    )
+    ```
+    """
+    nan_columns = [c for c in df.columns if c not in groupby_columns]
+
+    num_nans_detected = (
+        df[nan_columns]
+        .isnull()
+        .groupby([df[c] for c in groupby_columns], **kwargs)
+        .sum()
+    )
+
+    return cast(pd.DataFrame, num_nans_detected)
 
 
 def multi_merge(

--- a/owid/datautils/dataframes.py
+++ b/owid/datautils/dataframes.py
@@ -69,8 +69,10 @@ def compare(
     # Compare, column by column, the elements of the two dataframes.
     compared = pd.DataFrame()
     for col in columns:
-        if (df1[col].dtype == object) or (df2[col].dtype == object):
-            # Apply a direct comparison for strings.
+        if (df1[col].dtype in (object, "category")) or (
+            df2[col].dtype in (object, "category")
+        ):
+            # Apply a direct comparison for strings or categories
             compared_row = df1[col].values == df2[col].values
         else:
             # For numeric data, consider them equal within certain absolute and relative tolerances.

--- a/owid/datautils/geo.py
+++ b/owid/datautils/geo.py
@@ -1,12 +1,13 @@
 """Utils related to geographical entities."""
 
+import functools
 import json
 import warnings
-from typing import List, Union, Optional, Dict, Any, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import numpy as np
-import pandas as pd
 import owid.catalog as catalog
+import pandas as pd
 
 from owid.datautils.common import ExceptionFromDocstring, warn_on_list_of_entities
 from owid.datautils.dataframes import groupby_agg, map_series
@@ -27,6 +28,7 @@ FRAC_ALLOWED_NANS_PER_YEAR = 0.2
 NUM_ALLOWED_NANS_PER_YEAR = None
 
 
+@functools.lru_cache
 def _load_population() -> pd.DataFrame:
     population = (
         catalog.find("population", namespace="owid", dataset="key_indicators")
@@ -37,6 +39,7 @@ def _load_population() -> pd.DataFrame:
     return cast(pd.DataFrame, population)
 
 
+@functools.lru_cache
 def _load_countries_regions() -> pd.DataFrame:
     countries_regions = catalog.find(
         "countries_regions", dataset="reference", namespace="owid"
@@ -45,6 +48,7 @@ def _load_countries_regions() -> pd.DataFrame:
     return cast(pd.DataFrame, countries_regions)
 
 
+@functools.lru_cache
 def _load_income_groups() -> pd.DataFrame:
     income_groups_found = catalog.find(
         table="wb_income_group", dataset="wb_income", namespace="wb"

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -692,6 +692,38 @@ class TestGroupbyAggregate:
             df2=df_out,
         )
 
+    def test_categorical_agg(self):
+        # Make sure grouped object only contains observed combinations of categories
+        df_in = pd.DataFrame(
+            {
+                "col_01": ["a", "a", "c"],
+                "col_02": ["b", "b", "d"],
+                "col_03": [1, 2, 3],
+            }
+        ).astype(
+            {
+                "col_01": "category",
+                "col_02": "category",
+            }
+        )
+
+        df_out = pd.DataFrame(
+            {"col_01": ["a", "c"], "col_02": ["b", "d"], "col_03": [3, 3]}
+        ).astype(
+            {
+                "col_01": "category",
+                "col_02": "category",
+            }
+        )
+
+        df_exp = dataframes.groupby_agg(df_in, ["col_01", "col_02"]).reset_index()
+
+        assert dataframes.are_equal(
+            df1=df_exp,
+            df2=df_out,
+            verbose=True,
+        )[0]
+
 
 class TestMultiMerge:
     df1 = pd.DataFrame({"col_01": ["aa", "ab", "ac"], "col_02": ["ba", "bb", "bc"]})


### PR DESCRIPTION
Category dtypes in keys of `groupby` command cause size explosion of grouped dataframe since every combination of categories in keys gets their own group. Using `observed` solves that (and it is turned on by default).

I've also added caching of population, income groups and countries regions to memory as they never change during execution and it helps a lot with performance.